### PR TITLE
feat: :sparkles: Multiple companies feature

### DIFF
--- a/src/app/components/app-container.jsx
+++ b/src/app/components/app-container.jsx
@@ -2,34 +2,54 @@
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
 import React, { useState, useCallback, useEffect } from 'react'
 import LoadingSpinner from './loadingSpinner'
+import { CompaniesSelect } from './companiesSelect'
+import { lastCompanySelectedKey } from '@/utils/localStorage'
+import { useRouter } from 'next/navigation'
 
 export default function AppContainer({session, src}) {
 
+
   const supabase = createClientComponentClient({ cookieOptions: {domain: process.env.NEXT_PUBLIC_COOKIE_DOMAIN, path: "/"} })
   const [loading, setLoading] = useState(true)
-  const [companyId, setCompanyId] = useState(null)
+  const [currentCompanyId, setCurrentCompanyId] = useState(null)
+  const [companies, setCompanies] = useState([])
   const [contactId, setContactId] = useState(null)
+  const route = useRouter()
   const user = session?.user
-
+  // console.log("user ==>", user)
   const getCompanyId = useCallback(async () => {
     try {
       setLoading(true)
-
-      let { data, error, status } = await supabase
+      const { data, error, status } = await supabase
         .from('profiles')
-        .select('company_id,contact_id')
+        .select('id,company_id,contact_id')
         .eq('user_id', user?.id)
         .single()
 
-      if (error && status !== 406) {
-        throw error
-      }
-
+      const getAllcompanies =  await supabase 
+        .from('profile_company')
+        .select('id,company_id,company_name')
+        .eq('profile_id', data.id) 
+     
+        
+        if(getAllcompanies.data.length < 1) {
+          route.push(`https://auth.oohinfo.org/awaiting`)
+          return;
+        }
+        if ( (error && status !== 406) || (getAllcompanies.error && getAllcompanies.status !== 406)) {
+          throw error
+        }
+        setCompanies(getAllcompanies.data)
+        const lastCompanySelected = localStorage.getItem(lastCompanySelectedKey)
+        const ensureCompany = getAllcompanies.data.find(({company_id}) => company_id === lastCompanySelected)  
+       
+        lastCompanySelected && ensureCompany ? setCurrentCompanyId(lastCompanySelected) : setCurrentCompanyId(getAllcompanies.data[0].company_id)
       if (data) {
-        setCompanyId(data.company_id)
+        // setCompanyId(data.company_id)
         setContactId(data.contact_id)
       }
     } catch (error) {
+      console.log(error)
       alert('Error loading user data!')
     } finally {
       setLoading(false)
@@ -38,6 +58,7 @@ export default function AppContainer({session, src}) {
 
   useEffect(() => {
     getCompanyId()
+    
   }, [user, getCompanyId])
 
   if (loading) {
@@ -47,11 +68,25 @@ export default function AppContainer({session, src}) {
       </div>
     )
   }
-  const appUrl = `${src}?company_id=${companyId}&user_id=${user?.id}&contact_id=${contactId}`
+  function handleCompanyChange(id) {
+    setCurrentCompanyId(id)
 
+    localStorage.setItem(lastCompanySelectedKey, id)
+  }
+  const appUrl = `${src}?company_id=${currentCompanyId}&user_id=${user?.id}&contact_id=${contactId}`
   return (
-    <>
+
+     <div className=" w-full  flex flex-col bg-[#3A435F]">
+      <div className='ml-4'>
+        <CompaniesSelect 
+        defaultValue={currentCompanyId}
+        companies={companies} 
+        onCompanyChange={(event) => {
+          handleCompanyChange(event.target.value)
+        }}/>
+      </div>
       {<iframe src={appUrl} width="100%" height="100%" className='bg-[#3a435f]'></iframe>}
-    </>
+    </div>
+   
   )
 }

--- a/src/app/components/companiesSelect.js
+++ b/src/app/components/companiesSelect.js
@@ -1,0 +1,18 @@
+export function CompaniesSelect({onCompanyChange, companies, defaultValue}) {
+  return (
+    <nav>
+      <h1 className='text-white text-lg mb-2 mt-4'>My companies</h1>
+      <select
+        defaultValue={defaultValue}
+        disabled={companies.length <= 1} 
+        className="block max-w-[40%] bg-white border border-gray-300 text-gray-700 py-2 px-4 pr-8 rounded leading-tight focus:outline-none focus:border-blue-500  " 
+        onChange={onCompanyChange}
+      >
+        {companies.map(({id,company_id, company_name}) => {
+          return  <option key={id} value={company_id}>{company_name}</option>
+          })}
+
+      </select>
+    </nav>
+  )
+}

--- a/src/utils/localStorage.js
+++ b/src/utils/localStorage.js
@@ -1,0 +1,3 @@
+const storageKey = "@oohinfo"
+
+export const lastCompanySelectedKey = `${storageKey}:lastCompanySelected`


### PR DESCRIPTION
**ticket**: https://trello.com/c/KoUt3Efs/47-select-company-to-view-in-charger

About the feature:

Now customers on the charger portal can choose which company they can see the data, an example:

Lindmark Outdoor data:
![image](https://github.com/automatearmy/test-app-a/assets/69018716/d9057f9a-f45b-4df2-90b1-c67f5c8470b3)

Metro Outdoor data:
![image](https://github.com/automatearmy/test-app-a/assets/69018716/6ffb3aa0-b48a-4021-8455-800482f7d7ee)

Observations:

- Users without one or more companies will be redirected to the awaiting approval page
- The companies dropdown will be disabled for users with a single company.
- We're using localStorage to save the last company selected on the dropdown


